### PR TITLE
feat: add detachInstance behavior simulation for instance node

### DIFF
--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -490,6 +490,10 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
+
+    detachInstance(): void {
+      this.type = "FRAME";
+    }
   }
 
   applyMixins(InstanceNodeStub, [


### PR DESCRIPTION
Add `detachInstance` behavior simulation for instance node

Related to [The issue in react-figma](https://github.com/react-figma/react-figma/pull/432/files)

Also FYI, I did try to add some tests for this code change but the tests (including the existing ones) seem to fail due to some typescript errors 