### PR TITLE
Update typings and fix find functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/react-figma/figma-api-stub#readme",
   "devDependencies": {
-    "@figma/plugin-typings": "^1.15.0",
+    "@figma/plugin-typings": "^1.42.1",
     "@types/jest": "^24.0.23",
     "cross-env": "^6.0.3",
     "jest": "^24.9.0",

--- a/src/__tests__/component.test.ts
+++ b/src/__tests__/component.test.ts
@@ -1,0 +1,14 @@
+import { createFigma } from "../stubs";
+
+describe("allocating id", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({});
+  });
+
+  it("generates an instance that's connected to the main component", () => {
+    const component = figma.createComponent();
+    const instance = component.createInstance();
+    expect(instance.mainComponent).toBe(component);
+  });
+});

--- a/src/__tests__/find.test.ts
+++ b/src/__tests__/find.test.ts
@@ -1,0 +1,113 @@
+import { createFigma } from "../stubs";
+
+describe("find functions", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({});
+  });
+
+  describe("findAll", () => {
+    it("returns all children and subchildren that adheres to the given callback", () => {
+      const component1 = figma.createComponent();
+      const rect1 = figma.createRectangle();
+      const rect2 = figma.createRectangle();
+      const rect3 = figma.createRectangle();
+      figma.group([rect1, rect2, rect3], component1);
+
+      //   component1.appendChild(rectGroup);
+
+      const foundChildren = component1.findAll(() => true);
+
+      expect(foundChildren.length).toBe(4);
+    });
+  });
+
+  describe("findOne", () => {
+    it("returns the first child or subchild that adheres to the given callback", () => {
+      const component1 = figma.createComponent();
+      const rect1 = figma.createRectangle();
+      rect1.name = "FIND_ME";
+      const rect2 = figma.createRectangle();
+      const rect3 = figma.createRectangle();
+
+      figma.group([rect1, rect2, rect3], component1);
+
+      const foundChild = component1.findOne(node => node.name === "FIND_ME");
+
+      expect(foundChild).not.toBeNull();
+      expect(foundChild).toBe(rect1);
+    });
+  });
+
+  describe("findChildren", () => {
+    it("returns all immediate children that adheres to the given callback", () => {
+      const component1 = figma.createComponent();
+      const rect1 = figma.createRectangle();
+      rect1.name = "FIND_ME";
+      const rect2 = figma.createRectangle();
+      rect2.name = "FIND_ME";
+      const rect3 = figma.createRectangle();
+      rect3.name = "FIND_ME";
+
+      figma.group([rect1], component1);
+      component1.appendChild(rect2);
+      component1.appendChild(rect3);
+
+      //   component1.appendChild(rectGroup);
+
+      const foundChildren = component1.findChildren(
+        node => node.name === "FIND_ME"
+      );
+
+      expect(foundChildren.length).toBe(2);
+      expect(foundChildren).toContain(rect2);
+      expect(foundChildren).toContain(rect3);
+    });
+  });
+
+  describe("findChild", () => {
+    it("returns the first immediate child that adheres to the given callback", () => {
+      const component1 = figma.createComponent();
+      const rect1 = figma.createRectangle();
+      rect1.name = "FIND_ME";
+      const rect2 = figma.createRectangle();
+      rect2.name = "FIND_ME";
+      const rect3 = figma.createRectangle();
+      rect3.name = "FIND_ME";
+
+      figma.group([rect1], component1);
+      component1.appendChild(rect2);
+      component1.appendChild(rect3);
+
+      //   component1.appendChild(rectGroup);
+
+      const foundChild = component1.findChild(node => node.name === "FIND_ME");
+
+      expect(foundChild).not.toBeNull();
+      expect(foundChild).toBe(rect2);
+    });
+  });
+
+  describe("findAllWithCriteria", () => {
+    it("returns all children that match the specified types", () => {
+      const component1 = figma.createComponent();
+      const component2 = figma.createComponent();
+      const rect1 = figma.createRectangle();
+      const rect2 = figma.createRectangle();
+      const rect3 = figma.createRectangle();
+      const instance = component2.createInstance();
+
+      component1.appendChild(rect1);
+      component1.appendChild(rect2);
+      component1.appendChild(rect3);
+      component1.appendChild(instance);
+
+      const foundChildren = component1.findAllWithCriteria({
+        types: ["INSTANCE"]
+      });
+
+      expect(foundChildren.length).toBe(1);
+      expect(foundChildren[0]).toBe(instance);
+    });
+  });
+});

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -14,6 +14,13 @@ describe("getPluginData", () => {
     expect(rect.getPluginData("key")).toEqual("value");
   });
 
+  it("can retreive keys", () => {
+    const rect = figma.createRectangle();
+    rect.setPluginData("key1", "value");
+    rect.setPluginData("key2", "value");
+    expect(rect.getPluginDataKeys()).toEqual(["key1", "key2"]);
+  });
+
   it("removed node throws error", () => {
     const rect = figma.createRectangle();
     rect.setPluginData("key", "value");

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -542,10 +542,12 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   class ComponentNodeStub {
     type = "COMPONENT";
+    key = nanoid(40);
     children = [];
     createInstance() {
       const instance = new InstanceNodeStub();
       instance.children = cloneDeep(this.children);
+      instance.mainComponent = this;
       return instance;
     }
   }
@@ -561,6 +563,7 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
+    mainComponent: null | ComponentNodeStub;
 
     detachInstance(): void {
       this.type = "FRAME";

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@figma/plugin-typings@^1.15.0":
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@figma/plugin-typings/-/plugin-typings-1.15.0.tgz#7563639f2ee44b118a136be78d754fa2cc4f3ede"
-  integrity sha512-Lr6QShIKlQNW9qdnneGr5+TIXH+EvapyfDvaaZHj7rACqIEslkZmH1mV4AmQHEs9FK5rqJMmKfSkNUNM2fztPg==
+"@figma/plugin-typings@^1.42.1":
+  version "1.42.1"
+  resolved "https://artifactory.service.bo1.csnzoo.com/artifactory/api/npm/npm/@figma/plugin-typings/-/plugin-typings-1.42.1.tgz#b9999c3d162db9b3d384c609b15ed18e49b0540f"
+  integrity sha1-uZmcPRYtubPThMYJsV7RjkmwVA8=
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"


### PR DESCRIPTION
## Changes

* update `@figma/plugin-typings` to its latest version
* Update `stubs.ts` to fix errors caused by new typings
* Change behavior of "find" functions (`findAll`, `findOne`, `findChild`, and `findChildren`) to more closely match their described behavior
* add `findAllWithCriteria`
* add `key` to ComponentNodeStub
* add `mainComponent` to InstanceNodeStub
* add tests for "find" functions

## Descriptions

When I was updating this to work with the latest figma types, I noticed
that the "find" functions didn't work as specified. Most notably,
findAll and findOne didn't recursively search for subchildren. Added
that functionality and updated the tests