### PR TITLE
Make pluginData and sharedPluginData for components and instances behave more like in Figma

### DIFF
--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -31,109 +31,228 @@ describe("getPluginData", () => {
   });
 
   describe("components and instances", () => {
-    it("instances inherit plugin data from main component", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+    describe("pluginData", () => {
+      it("instances inherit plugin data from main component", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
 
-      const instance = component.createInstance();
+        const instance = component.createInstance();
 
-      expect(instance.getPluginData("foo")).toBe("bar");
+        expect(instance.getPluginData("foo")).toBe("bar");
+      });
+
+      it("the children of instances inherit data from the main component", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setPluginData("foo", "bar");
+        component.appendChild(componentRect);
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
+
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getPluginData("foo")).toBe("bar");
+      });
+
+      it("modifying the plugin data of the main component modifies the instance", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+
+        component.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+      });
+
+      it("modifying the plugin data of the main component child modifies the instance child", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setPluginData("foo", "bar");
+        component.appendChild(componentRect);
+
+        const instance = component.createInstance();
+        componentRect.setPluginData("foo", "baz");
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
+
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+      });
+
+      it("instances can override the main component plugin data", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        instance.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+      });
+
+      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        instance.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+
+        instance.setPluginData("foo", "");
+        expect(instance.getPluginData("foo")).toBe("bar");
+      });
+
+      it("the children of instances can override the children of main component plugin data", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setPluginData("foo", "baz");
+
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+        expect(componentRect.getPluginData("foo")).toBe("bar");
+      });
+
+      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setPluginData("foo", "baz");
+
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+
+        instanceRect.setPluginData("foo", "");
+
+        expect(componentRect.getPluginData("foo")).toBe("bar");
+        expect(instanceRect.getPluginData("foo")).toBe("bar");
+      });
     });
 
-    it("the children of instances inherit data from the main component", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      componentRect.setPluginData("foo", "bar");
-      component.appendChild(componentRect);
+    describe("sharedPluginData", () => {
+      it("instances inherit plugin data from main component", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+        const instance = component.createInstance();
 
-      expect(instanceRect).not.toBeNull();
-      expect(instanceRect.getPluginData("foo")).toBe("bar");
-    });
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-    it("modifying the plugin data of the main component modifies the instance", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("the children of instances inherit data from the main component", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setSharedPluginData("shared", "foo", "bar");
+        component.appendChild(componentRect);
 
-      const instance = component.createInstance();
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
 
-      component.setPluginData("foo", "baz");
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-      expect(instance.getPluginData("foo")).toBe("baz");
-    });
+      it("modifying the plugin data of the main component modifies the instance", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-    it("modifying the plugin data of the main component child modifies the instance child", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      componentRect.setPluginData("foo", "bar");
-      component.appendChild(componentRect);
+        const instance = component.createInstance();
 
-      const instance = component.createInstance();
-      componentRect.setPluginData("foo", "baz");
-      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+        component.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instanceRect).not.toBeNull();
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
-    });
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-    it("instances can override the main component plugin data", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("modifying the plugin data of the main component child modifies the instance child", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setSharedPluginData("shared", "foo", "bar");
+        component.appendChild(componentRect);
 
-      const instance = component.createInstance();
-      instance.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        componentRect.setSharedPluginData("shared", "foo", "baz");
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
 
-      expect(instance.getPluginData("foo")).toBe("baz");
-    });
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("instances can override the main component plugin data", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      instance.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        instance.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instance.getPluginData("foo")).toBe("baz");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-      instance.setPluginData("foo", "");
-      expect(instance.getPluginData("foo")).toBe("bar");
-    });
+      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-    it("the children of instances can override the children of main component plugin data", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      component.appendChild(componentRect);
-      componentRect.setPluginData("foo", "bar");
+        const instance = component.createInstance();
+        instance.setSharedPluginData("shared", "foo", "baz");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(
-        child => child.type === "RECTANGLE"
-      );
-      instanceRect.setPluginData("foo", "baz");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
 
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
-    });
+        instance.setSharedPluginData("shared", "foo", "");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      component.appendChild(componentRect);
-      componentRect.setPluginData("foo", "bar");
+      it("the children of instances can override the children of main component plugin data", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(
-        child => child.type === "RECTANGLE"
-      );
-      instanceRect.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-      instanceRect.setPluginData("foo", "");
+      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setSharedPluginData("shared", "foo", "bar");
 
-      expect(componentRect.getPluginData("foo")).toBe("bar");
-      expect(instanceRect.getPluginData("foo")).toBe("bar");
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setSharedPluginData("shared", "foo", "baz");
+
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+
+        instanceRect.setSharedPluginData("shared", "foo", "");
+
+        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
     });
   });
 });

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -30,7 +30,7 @@ describe("getPluginData", () => {
     }).toThrow("The node with id 1:2 does not exist");
   });
 
-  fdescribe("components and instances", () => {
+  describe("components and instances", () => {
     it("instances inherit plugin data from main component", () => {
       const component = figma.createComponent();
       component.setPluginData("foo", "bar");

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -29,4 +29,110 @@ describe("getPluginData", () => {
       rect.getPluginData("key");
     }).toThrow("The node with id 1:2 does not exist");
   });
+
+  describe("components and instances", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
+
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
+
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+
+      component.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
+
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      componentRect.setPluginData("foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
+
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
+
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+
+      instance.setPluginData("foo", "");
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
+
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
+
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
+
+    // it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+    //   const component = figma.createComponent();
+    //   const componentRect = figma.createRectangle();
+    //   component.appendChild(componentRect);
+    //   componentRect.setPluginData("foo", "bar");
+
+    //   const instance = component.createInstance();
+    //   const instanceRect = instance.findOne(
+    //     child => child.type === "RECTANGLE"
+    //   );
+    //   instanceRect.setPluginData("foo", "baz");
+
+    //   expect(instanceRect.getPluginData("foo")).toBe("baz");
+
+    //   componentRect.setPluginData("foo", "");
+
+    //   expect(instanceRect.getPluginData("foo")).toBe("bar");
+    // });
+  });
 });

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -30,7 +30,7 @@ describe("getPluginData", () => {
     }).toThrow("The node with id 1:2 does not exist");
   });
 
-  describe("components and instances", () => {
+  fdescribe("components and instances", () => {
     it("instances inherit plugin data from main component", () => {
       const component = figma.createComponent();
       component.setPluginData("foo", "bar");
@@ -116,23 +116,24 @@ describe("getPluginData", () => {
       expect(instanceRect.getPluginData("foo")).toBe("baz");
     });
 
-    // it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-    //   const component = figma.createComponent();
-    //   const componentRect = figma.createRectangle();
-    //   component.appendChild(componentRect);
-    //   componentRect.setPluginData("foo", "bar");
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-    //   const instance = component.createInstance();
-    //   const instanceRect = instance.findOne(
-    //     child => child.type === "RECTANGLE"
-    //   );
-    //   instanceRect.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-    //   expect(instanceRect.getPluginData("foo")).toBe("baz");
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
 
-    //   componentRect.setPluginData("foo", "");
+      instanceRect.setPluginData("foo", "");
 
-    //   expect(instanceRect.getPluginData("foo")).toBe("bar");
-    // });
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
   });
 });

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,5 +1,3 @@
-import * as cloneDeep from "clone-deep";
-import * as isPlainObject from "is-plain-object";
 import { Subject, Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 import { applyMixins } from "./applyMixins";
@@ -199,8 +197,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
     name: string;
     removed: boolean;
     relaunchData: { [command: string]: string };
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     setPluginData(key: string, value: string) {
       if (!this.pluginData) {
@@ -366,6 +364,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   }
   class RectangleNodeStub {
     type = "RECTANGLE";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(RectangleNodeStub, [
@@ -377,9 +377,13 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   class TextNodeStub {
     type = "TEXT";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     private _fontName: FontName;
     private _characters: string;
     private _textAutoResize: string;
+
     get fontName() {
       return this._fontName || { family: "Roboto", style: "Regular" };
     }
@@ -492,6 +496,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class DocumentNodeStub {
     type = "DOCUMENT";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(DocumentNodeStub, [BaseNodeMixinStub, ChildrenMixinStub]);
@@ -499,6 +505,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class PageNodeStub {
     type = "PAGE";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     _selection: Array<SceneNode>;
 
     get selection() {
@@ -520,6 +529,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class FrameNodeStub {
     type = "FRAME";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(FrameNodeStub, [
@@ -532,6 +543,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   class GroupNodeStub {
     type = "GROUP";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     set constraints(value) {
       if (joinedConfig.simulateErrors) {
@@ -549,6 +562,19 @@ export const createFigma = (config: TConfig): PluginAPI => {
     LayoutMixinStub
   ]);
 
+  function cloneChildren(node) {
+    const clone = new node.constructor();
+    for (let key in node) {
+      clone[key] = node[key];
+    }
+    if ("children" in node) {
+      clone.children = node.children.map(cloneChildren);
+    }
+    clone.pluginData = Object.create(node.pluginData);
+    clone.sharedPluginData = Object.create(node.sharedPluginData);
+    return clone;
+  }
+
   class ComponentNodeStub {
     type = "COMPONENT";
     children = [];
@@ -557,7 +583,7 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
     createInstance() {
       const instance = new InstanceNodeStub();
-      instance.children = cloneDeep(this.children);
+      instance.children = this.children.map(cloneChildren);
       instance.pluginData = Object.create(this.pluginData);
       instance.sharedPluginData = Object.create(this.sharedPluginData);
       return instance;
@@ -575,8 +601,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     detachInstance(): void {
       this.type = "FRAME";
@@ -609,8 +635,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
     removed: boolean;
 
     relaunchData: { [command: string]: string };
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     setPluginData(key: string, value: string) {
       if (!this.pluginData) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,4 +1,5 @@
 import * as cloneDeep from "clone-deep";
+import * as isPlainObject from "is-plain-object";
 import { Subject, Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 import { applyMixins } from "./applyMixins";
@@ -205,7 +206,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.pluginData) {
         this.pluginData = {};
       }
-      this.pluginData[key] = value;
+      if (value === "") {
+        delete this.pluginData[key];
+      } else {
+        this.pluginData[key] = value;
+      }
     }
 
     getPluginData(key: string) {
@@ -235,7 +240,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.sharedPluginData[namespace]) {
         this.sharedPluginData[namespace] = {};
       }
-      this.sharedPluginData[namespace][key] = value;
+      if (value === "") {
+        delete this.sharedPluginData[namespace][key];
+      } else {
+        this.sharedPluginData[namespace][key] = value;
+      }
     }
 
     getSharedPluginData(namespace: string, key: string) {
@@ -543,9 +552,14 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class ComponentNodeStub {
     type = "COMPONENT";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     createInstance() {
       const instance = new InstanceNodeStub();
       instance.children = cloneDeep(this.children);
+      instance.pluginData = Object.create(this.pluginData);
+      instance.sharedPluginData = Object.create(this.sharedPluginData);
       return instance;
     }
   }
@@ -561,6 +575,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
+    pluginData: { [key: string]: string };
+    sharedPluginData: { [namespace: string]: { [key: string]: string } };
 
     detachInstance(): void {
       this.type = "FRAME";
@@ -569,6 +585,7 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   applyMixins(InstanceNodeStub, [
     BaseNodeMixinStub,
+    ChildrenMixinStub,
     ExportMixinStub,
     LayoutMixinStub
   ]);
@@ -599,7 +616,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.pluginData) {
         this.pluginData = {};
       }
-      this.pluginData[key] = value;
+      if (value === "") {
+        delete this.pluginData[key];
+      } else {
+        this.pluginData[key] = value;
+      }
     }
 
     getPluginData(key: string) {
@@ -629,7 +650,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.sharedPluginData[namespace]) {
         this.sharedPluginData[namespace] = {};
       }
-      this.sharedPluginData[namespace][key] = value;
+      if (value === "") {
+        delete this.sharedPluginData[namespace][key];
+      } else {
+        this.sharedPluginData[namespace][key] = value;
+      }
     }
 
     getSharedPluginData(namespace: string, key: string) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -572,6 +572,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
     }
     clone.pluginData = Object.create(node.pluginData);
     clone.sharedPluginData = Object.create(node.sharedPluginData);
+    Object.entries(node.sharedPluginData).forEach(([key, val]) => {
+      clone.sharedPluginData[key] = Object.create(val as object);
+    });
     return clone;
   }
 
@@ -587,6 +590,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
       instance.children = this.children.map(cloneChildren);
       instance.pluginData = Object.create(this.pluginData);
       instance.sharedPluginData = Object.create(this.sharedPluginData);
+      Object.entries(this.sharedPluginData).forEach(([key, val]) => {
+        instance.sharedPluginData[key] = Object.create(val as object);
+      });
       instance.mainComponent = this;
       return instance;
     }


### PR DESCRIPTION
This is a continuation of the edits I made in [this PR](https://github.com/react-figma/figma-api-stub/pull/40/files), so we should probably confirm that those are okay before merging this in

* This change updates pluginData to more closely mimic how figma handles inheritance for components and instances. 
* It also adds some test cases to ensure everything works correctly. 
* The biggest changes are in the "get" and "set" pluginData functions, and in "createInstance". 
* As part of this change, I removed the calls to `cloneDeep` and replaced it with a custom function. Based on what I read of the [source code](https://github.com/jonschlinkert/clone-deep/blob/master/index.js#L23) this should handle most of the same needs, but maybe we should use something like shallow-clone to handle some of the copying 🤔. We might also need a better way to deep-clone arrays