### PR TITLE
Plugin data updates for instances v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "jest"
   },
   "jest": {
-    "preset": "ts-jest/presets/js-with-babel"
+    "preset": "ts-jest/presets/js-with-babel",
+    "silent": false
   },
   "pre-commit": [
     "prettify",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test": "jest"
   },
   "jest": {
-    "preset": "ts-jest/presets/js-with-babel",
-    "silent": false
+    "preset": "ts-jest/presets/js-with-babel"
   },
   "pre-commit": [
     "prettify",

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -21,6 +21,48 @@ describe("getPluginData", () => {
     expect(rect.getPluginDataKeys()).toEqual(["key1", "key2"]);
   });
 
+  it("can retreive inherited pluginData keys from the main component", () => {
+    const component = figma.createComponent();
+    const componentRect = figma.createRectangle();
+    componentRect.setPluginData("key1", "value1");
+    component.appendChild(componentRect);
+
+    const instance = component.createInstance();
+    const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+    instanceRect.setPluginData("key2", "value2");
+
+    expect(componentRect.getPluginDataKeys()).toEqual(
+      expect.arrayContaining(["key1"])
+    );
+    expect(componentRect.getPluginDataKeys()).toHaveLength(1);
+
+    expect(instanceRect.getPluginDataKeys()).toEqual(
+      expect.arrayContaining(["key1", "key2"])
+    );
+    expect(instanceRect.getPluginDataKeys()).toHaveLength(2);
+  });
+
+  it("can retreive inherited sharedPluginData keys from the main component", () => {
+    const component = figma.createComponent();
+    const componentRect = figma.createRectangle();
+    componentRect.setSharedPluginData("shared", "key1", "value1");
+    component.appendChild(componentRect);
+
+    const instance = component.createInstance();
+    const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+    instanceRect.setSharedPluginData("shared", "key2", "value2");
+
+    expect(componentRect.getSharedPluginDataKeys("shared")).toEqual(
+      expect.arrayContaining(["key1"])
+    );
+    expect(componentRect.getSharedPluginDataKeys("shared")).toHaveLength(1);
+
+    expect(instanceRect.getSharedPluginDataKeys("shared")).toEqual(
+      expect.arrayContaining(["key1", "key2"])
+    );
+    expect(instanceRect.getSharedPluginDataKeys("shared")).toHaveLength(2);
+  });
+
   it("removed node throws error", () => {
     const rect = figma.createRectangle();
     rect.setPluginData("key", "value");

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -29,230 +29,249 @@ describe("getPluginData", () => {
       rect.getPluginData("key");
     }).toThrow("The node with id 1:2 does not exist");
   });
+});
 
-  describe("components and instances", () => {
-    describe("pluginData", () => {
-      it("instances inherit plugin data from main component", () => {
-        const component = figma.createComponent();
-        component.setPluginData("foo", "bar");
+describe("components and instances", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({
+      simulateErrors: true
+    });
+  });
 
-        const instance = component.createInstance();
+  describe("pluginData", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-        expect(instance.getPluginData("foo")).toBe("bar");
-      });
+      const instance = component.createInstance();
 
-      it("the children of instances inherit data from the main component", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        componentRect.setPluginData("foo", "bar");
-        component.appendChild(componentRect);
-
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          node => node.type === "RECTANGLE"
-        );
-
-        expect(instanceRect).not.toBeNull();
-        expect(instanceRect.getPluginData("foo")).toBe("bar");
-      });
-
-      it("modifying the plugin data of the main component modifies the instance", () => {
-        const component = figma.createComponent();
-        component.setPluginData("foo", "bar");
-
-        const instance = component.createInstance();
-
-        component.setPluginData("foo", "baz");
-
-        expect(instance.getPluginData("foo")).toBe("baz");
-      });
-
-      it("modifying the plugin data of the main component child modifies the instance child", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        componentRect.setPluginData("foo", "bar");
-        component.appendChild(componentRect);
-
-        const instance = component.createInstance();
-        componentRect.setPluginData("foo", "baz");
-        const instanceRect = instance.findOne(
-          node => node.type === "RECTANGLE"
-        );
-
-        expect(instanceRect).not.toBeNull();
-        expect(instanceRect.getPluginData("foo")).toBe("baz");
-      });
-
-      it("instances can override the main component plugin data", () => {
-        const component = figma.createComponent();
-        component.setPluginData("foo", "bar");
-
-        const instance = component.createInstance();
-        instance.setPluginData("foo", "baz");
-
-        expect(instance.getPluginData("foo")).toBe("baz");
-      });
-
-      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-        const component = figma.createComponent();
-        component.setPluginData("foo", "bar");
-
-        const instance = component.createInstance();
-        instance.setPluginData("foo", "baz");
-
-        expect(instance.getPluginData("foo")).toBe("baz");
-
-        instance.setPluginData("foo", "");
-        expect(instance.getPluginData("foo")).toBe("bar");
-      });
-
-      it("the children of instances can override the children of main component plugin data", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        component.appendChild(componentRect);
-        componentRect.setPluginData("foo", "bar");
-
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          child => child.type === "RECTANGLE"
-        );
-        instanceRect.setPluginData("foo", "baz");
-
-        expect(instanceRect.getPluginData("foo")).toBe("baz");
-        expect(componentRect.getPluginData("foo")).toBe("bar");
-      });
-
-      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        component.appendChild(componentRect);
-        componentRect.setPluginData("foo", "bar");
-
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          child => child.type === "RECTANGLE"
-        );
-        instanceRect.setPluginData("foo", "baz");
-
-        expect(instanceRect.getPluginData("foo")).toBe("baz");
-
-        instanceRect.setPluginData("foo", "");
-
-        expect(componentRect.getPluginData("foo")).toBe("bar");
-        expect(instanceRect.getPluginData("foo")).toBe("bar");
-      });
+      expect(instance.getPluginData("foo")).toBe("bar");
     });
 
-    describe("sharedPluginData", () => {
-      it("instances inherit plugin data from main component", () => {
-        const component = figma.createComponent();
-        component.setSharedPluginData("shared", "foo", "bar");
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
 
-        const instance = component.createInstance();
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
-      });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
 
-      it("the children of instances inherit data from the main component", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        componentRect.setSharedPluginData("shared", "foo", "bar");
-        component.appendChild(componentRect);
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          node => node.type === "RECTANGLE"
-        );
+      const instance = component.createInstance();
 
-        expect(instanceRect).not.toBeNull();
-        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
-      });
+      component.setPluginData("foo", "baz");
 
-      it("modifying the plugin data of the main component modifies the instance", () => {
-        const component = figma.createComponent();
-        component.setSharedPluginData("shared", "foo", "bar");
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
 
-        const instance = component.createInstance();
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
 
-        component.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      componentRect.setPluginData("foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
-      });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
 
-      it("modifying the plugin data of the main component child modifies the instance child", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        componentRect.setSharedPluginData("shared", "foo", "bar");
-        component.appendChild(componentRect);
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-        const instance = component.createInstance();
-        componentRect.setSharedPluginData("shared", "foo", "baz");
-        const instanceRect = instance.findOne(
-          node => node.type === "RECTANGLE"
-        );
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
 
-        expect(instanceRect).not.toBeNull();
-        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
-      });
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
 
-      it("instances can override the main component plugin data", () => {
-        const component = figma.createComponent();
-        component.setSharedPluginData("shared", "foo", "bar");
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-        const instance = component.createInstance();
-        instance.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
 
-        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
-      });
+      expect(instance.getPluginData("foo")).toBe("baz");
 
-      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-        const component = figma.createComponent();
-        component.setSharedPluginData("shared", "foo", "bar");
+      instance.setPluginData("foo", "");
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
 
-        const instance = component.createInstance();
-        instance.setSharedPluginData("shared", "foo", "baz");
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-        instance.setSharedPluginData("shared", "foo", "");
-        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
-      });
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+    });
 
-      it("the children of instances can override the children of main component plugin data", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        component.appendChild(componentRect);
-        componentRect.setSharedPluginData("shared", "foo", "bar");
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          child => child.type === "RECTANGLE"
-        );
-        instanceRect.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
-        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
-      });
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
 
-      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-        const component = figma.createComponent();
-        const componentRect = figma.createRectangle();
-        component.appendChild(componentRect);
-        componentRect.setSharedPluginData("shared", "foo", "bar");
+      instanceRect.setPluginData("foo", "");
 
-        const instance = component.createInstance();
-        const instanceRect = instance.findOne(
-          child => child.type === "RECTANGLE"
-        );
-        instanceRect.setSharedPluginData("shared", "foo", "baz");
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
+  });
 
-        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+  describe("sharedPluginData", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
 
-        instanceRect.setSharedPluginData("shared", "foo", "");
+      const instance = component.createInstance();
 
-        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
-        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
-      });
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
+
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
+
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
+
+      const instance = component.createInstance();
+
+      component.setSharedPluginData("shared", "foo", "baz");
+
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
+
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      componentRect.setSharedPluginData("shared", "foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
+
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setSharedPluginData("shared", "foo", "baz");
+
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
+
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setSharedPluginData("shared", "foo", "baz");
+
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+
+      instance.setSharedPluginData("shared", "foo", "");
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
+
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "baz");
+
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+      expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
+
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "baz");
+
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+
+      instanceRect.setSharedPluginData("shared", "foo", "");
+
+      expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
+
+    it("if an instance attempts to get plugin data before its set on the main component, it can still access main component data after it's been defined", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "bar");
+      componentRect.setSharedPluginData("shared", "baz", "bing");
+
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      expect(instanceRect.getSharedPluginData("shared", "baz")).toBe("bing");
+      expect(
+        componentRect.getSharedPluginData("shared", "foo")
+      ).toBeUndefined();
+      expect(componentRect.getSharedPluginData("shared", "baz")).toBe("bing");
     });
   });
 });

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -31,247 +31,247 @@ describe("getPluginData", () => {
   });
 });
 
-// describe("components and instances", () => {
-//   beforeEach(() => {
-//     // @ts-ignore
-//     global.figma = createFigma({
-//       simulateErrors: true
-//     });
-//   });
+describe("components and instances", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({
+      simulateErrors: true
+    });
+  });
 
-//   describe("pluginData", () => {
-//     it("instances inherit plugin data from main component", () => {
-//       const component = figma.createComponent();
-//       component.setPluginData("foo", "bar");
+  describe("pluginData", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
+      const instance = component.createInstance();
 
-//       expect(instance.getPluginData("foo")).toBe("bar");
-//     });
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
 
-//     it("the children of instances inherit data from the main component", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       componentRect.setPluginData("foo", "bar");
-//       component.appendChild(componentRect);
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-//       expect(instanceRect).not.toBeNull();
-//       expect(instanceRect.getPluginData("foo")).toBe("bar");
-//     });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
 
-//     it("modifying the plugin data of the main component modifies the instance", () => {
-//       const component = figma.createComponent();
-//       component.setPluginData("foo", "bar");
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
+      const instance = component.createInstance();
 
-//       component.setPluginData("foo", "baz");
+      component.setPluginData("foo", "baz");
 
-//       expect(instance.getPluginData("foo")).toBe("baz");
-//     });
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
 
-//     it("modifying the plugin data of the main component child modifies the instance child", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       componentRect.setPluginData("foo", "bar");
-//       component.appendChild(componentRect);
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
 
-//       const instance = component.createInstance();
-//       componentRect.setPluginData("foo", "baz");
-//       const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+      const instance = component.createInstance();
+      componentRect.setPluginData("foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-//       expect(instanceRect).not.toBeNull();
-//       expect(instanceRect.getPluginData("foo")).toBe("baz");
-//     });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
 
-//     it("instances can override the main component plugin data", () => {
-//       const component = figma.createComponent();
-//       component.setPluginData("foo", "bar");
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
-//       instance.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
 
-//       expect(instance.getPluginData("foo")).toBe("baz");
-//     });
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
 
-//     it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-//       const component = figma.createComponent();
-//       component.setPluginData("foo", "bar");
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
-//       instance.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
 
-//       expect(instance.getPluginData("foo")).toBe("baz");
+      expect(instance.getPluginData("foo")).toBe("baz");
 
-//       instance.setPluginData("foo", "");
-//       expect(instance.getPluginData("foo")).toBe("bar");
-//     });
+      instance.setPluginData("foo", "");
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
 
-//     it("the children of instances can override the children of main component plugin data", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       component.appendChild(componentRect);
-//       componentRect.setPluginData("foo", "bar");
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(
-//         child => child.type === "RECTANGLE"
-//       );
-//       instanceRect.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-//       expect(instanceRect.getPluginData("foo")).toBe("baz");
-//       expect(componentRect.getPluginData("foo")).toBe("bar");
-//     });
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+    });
 
-//     it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       component.appendChild(componentRect);
-//       componentRect.setPluginData("foo", "bar");
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(
-//         child => child.type === "RECTANGLE"
-//       );
-//       instanceRect.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-//       expect(instanceRect.getPluginData("foo")).toBe("baz");
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
 
-//       instanceRect.setPluginData("foo", "");
+      instanceRect.setPluginData("foo", "");
 
-//       expect(componentRect.getPluginData("foo")).toBe("bar");
-//       expect(instanceRect.getPluginData("foo")).toBe("bar");
-//     });
-//   });
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
+  });
 
-//   describe("sharedPluginData", () => {
-//     it("instances inherit plugin data from main component", () => {
-//       const component = figma.createComponent();
-//       component.setSharedPluginData("shared", "foo", "bar");
+  describe("sharedPluginData", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
+      const instance = component.createInstance();
 
-//       expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
-//     });
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
 
-//     it("the children of instances inherit data from the main component", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       componentRect.setSharedPluginData("shared", "foo", "bar");
-//       component.appendChild(componentRect);
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+      component.appendChild(componentRect);
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-//       expect(instanceRect).not.toBeNull();
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
-//     });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
 
-//     it("modifying the plugin data of the main component modifies the instance", () => {
-//       const component = figma.createComponent();
-//       component.setSharedPluginData("shared", "foo", "bar");
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
+      const instance = component.createInstance();
 
-//       component.setSharedPluginData("shared", "foo", "baz");
+      component.setSharedPluginData("shared", "foo", "baz");
 
-//       expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
-//     });
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
 
-//     it("modifying the plugin data of the main component child modifies the instance child", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       componentRect.setSharedPluginData("shared", "foo", "bar");
-//       component.appendChild(componentRect);
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setSharedPluginData("shared", "foo", "bar");
+      component.appendChild(componentRect);
 
-//       const instance = component.createInstance();
-//       componentRect.setSharedPluginData("shared", "foo", "baz");
-//       const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+      const instance = component.createInstance();
+      componentRect.setSharedPluginData("shared", "foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
 
-//       expect(instanceRect).not.toBeNull();
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
-//     });
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
 
-//     it("instances can override the main component plugin data", () => {
-//       const component = figma.createComponent();
-//       component.setSharedPluginData("shared", "foo", "bar");
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
-//       instance.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      instance.setSharedPluginData("shared", "foo", "baz");
 
-//       expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
-//     });
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+    });
 
-//     it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-//       const component = figma.createComponent();
-//       component.setSharedPluginData("shared", "foo", "bar");
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
-//       instance.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      instance.setSharedPluginData("shared", "foo", "baz");
 
-//       expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
 
-//       instance.setSharedPluginData("shared", "foo", "");
-//       expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
-//     });
+      instance.setSharedPluginData("shared", "foo", "");
+      expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
 
-//     it("the children of instances can override the children of main component plugin data", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       component.appendChild(componentRect);
-//       componentRect.setSharedPluginData("shared", "foo", "bar");
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(
-//         child => child.type === "RECTANGLE"
-//       );
-//       instanceRect.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "baz");
 
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
-//       expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
-//     });
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+      expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
 
-//     it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       component.appendChild(componentRect);
-//       componentRect.setSharedPluginData("shared", "foo", "bar");
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setSharedPluginData("shared", "foo", "bar");
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(
-//         child => child.type === "RECTANGLE"
-//       );
-//       instanceRect.setSharedPluginData("shared", "foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "baz");
 
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
 
-//       instanceRect.setSharedPluginData("shared", "foo", "");
+      instanceRect.setSharedPluginData("shared", "foo", "");
 
-//       expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
-//     });
+      expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+    });
 
-//     it("if an instance attempts to get plugin data before its set on the main component, it can still access main component data after it's been defined", () => {
-//       const component = figma.createComponent();
-//       const componentRect = figma.createRectangle();
-//       component.appendChild(componentRect);
+    it("if an instance attempts to get plugin data before its set on the main component, it can still access main component data after it's been defined", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
 
-//       const instance = component.createInstance();
-//       const instanceRect = instance.findOne(
-//         child => child.type === "RECTANGLE"
-//       );
-//       instanceRect.setSharedPluginData("shared", "foo", "bar");
-//       componentRect.setSharedPluginData("shared", "baz", "bing");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setSharedPluginData("shared", "foo", "bar");
+      componentRect.setSharedPluginData("shared", "baz", "bing");
 
-//       expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
-//       expect(instanceRect.getSharedPluginData("shared", "baz")).toBe("bing");
-//       expect(
-//         componentRect.getSharedPluginData("shared", "foo")
-//       ).toBeUndefined();
-//       expect(componentRect.getSharedPluginData("shared", "baz")).toBe("bing");
-//     });
-//   });
-// });
+      expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      expect(instanceRect.getSharedPluginData("shared", "baz")).toBe("bing");
+      expect(
+        componentRect.getSharedPluginData("shared", "foo")
+      ).toBeUndefined();
+      expect(componentRect.getSharedPluginData("shared", "baz")).toBe("bing");
+    });
+  });
+});

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -31,109 +31,228 @@ describe("getPluginData", () => {
   });
 
   describe("components and instances", () => {
-    it("instances inherit plugin data from main component", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+    describe("pluginData", () => {
+      it("instances inherit plugin data from main component", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
 
-      const instance = component.createInstance();
+        const instance = component.createInstance();
 
-      expect(instance.getPluginData("foo")).toBe("bar");
+        expect(instance.getPluginData("foo")).toBe("bar");
+      });
+
+      it("the children of instances inherit data from the main component", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setPluginData("foo", "bar");
+        component.appendChild(componentRect);
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
+
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getPluginData("foo")).toBe("bar");
+      });
+
+      it("modifying the plugin data of the main component modifies the instance", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+
+        component.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+      });
+
+      it("modifying the plugin data of the main component child modifies the instance child", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setPluginData("foo", "bar");
+        component.appendChild(componentRect);
+
+        const instance = component.createInstance();
+        componentRect.setPluginData("foo", "baz");
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
+
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+      });
+
+      it("instances can override the main component plugin data", () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        instance.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+      });
+
+      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+        const component = figma.createComponent();
+        component.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        instance.setPluginData("foo", "baz");
+
+        expect(instance.getPluginData("foo")).toBe("baz");
+
+        instance.setPluginData("foo", "");
+        expect(instance.getPluginData("foo")).toBe("bar");
+      });
+
+      it("the children of instances can override the children of main component plugin data", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setPluginData("foo", "baz");
+
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+        expect(componentRect.getPluginData("foo")).toBe("bar");
+      });
+
+      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setPluginData("foo", "bar");
+
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setPluginData("foo", "baz");
+
+        expect(instanceRect.getPluginData("foo")).toBe("baz");
+
+        instanceRect.setPluginData("foo", "");
+
+        expect(componentRect.getPluginData("foo")).toBe("bar");
+        expect(instanceRect.getPluginData("foo")).toBe("bar");
+      });
     });
 
-    it("the children of instances inherit data from the main component", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      componentRect.setPluginData("foo", "bar");
-      component.appendChild(componentRect);
+    describe("sharedPluginData", () => {
+      it("instances inherit plugin data from main component", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+        const instance = component.createInstance();
 
-      expect(instanceRect).not.toBeNull();
-      expect(instanceRect.getPluginData("foo")).toBe("bar");
-    });
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-    it("modifying the plugin data of the main component modifies the instance", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("the children of instances inherit data from the main component", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setSharedPluginData("shared", "foo", "bar");
+        component.appendChild(componentRect);
 
-      const instance = component.createInstance();
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
 
-      component.setPluginData("foo", "baz");
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-      expect(instance.getPluginData("foo")).toBe("baz");
-    });
+      it("modifying the plugin data of the main component modifies the instance", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-    it("modifying the plugin data of the main component child modifies the instance child", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      componentRect.setPluginData("foo", "bar");
-      component.appendChild(componentRect);
+        const instance = component.createInstance();
 
-      const instance = component.createInstance();
-      componentRect.setPluginData("foo", "baz");
-      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+        component.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instanceRect).not.toBeNull();
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
-    });
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-    it("instances can override the main component plugin data", () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("modifying the plugin data of the main component child modifies the instance child", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        componentRect.setSharedPluginData("shared", "foo", "bar");
+        component.appendChild(componentRect);
 
-      const instance = component.createInstance();
-      instance.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        componentRect.setSharedPluginData("shared", "foo", "baz");
+        const instanceRect = instance.findOne(
+          node => node.type === "RECTANGLE"
+        );
 
-      expect(instance.getPluginData("foo")).toBe("baz");
-    });
+        expect(instanceRect).not.toBeNull();
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
-      const component = figma.createComponent();
-      component.setPluginData("foo", "bar");
+      it("instances can override the main component plugin data", () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      instance.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        instance.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instance.getPluginData("foo")).toBe("baz");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
+      });
 
-      instance.setPluginData("foo", "");
-      expect(instance.getPluginData("foo")).toBe("bar");
-    });
+      it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+        const component = figma.createComponent();
+        component.setSharedPluginData("shared", "foo", "bar");
 
-    it("the children of instances can override the children of main component plugin data", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      component.appendChild(componentRect);
-      componentRect.setPluginData("foo", "bar");
+        const instance = component.createInstance();
+        instance.setSharedPluginData("shared", "foo", "baz");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(
-        child => child.type === "RECTANGLE"
-      );
-      instanceRect.setPluginData("foo", "baz");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("baz");
 
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
-    });
+        instance.setSharedPluginData("shared", "foo", "");
+        expect(instance.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-      const component = figma.createComponent();
-      const componentRect = figma.createRectangle();
-      component.appendChild(componentRect);
-      componentRect.setPluginData("foo", "bar");
+      it("the children of instances can override the children of main component plugin data", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setSharedPluginData("shared", "foo", "bar");
 
-      const instance = component.createInstance();
-      const instanceRect = instance.findOne(
-        child => child.type === "RECTANGLE"
-      );
-      instanceRect.setPluginData("foo", "baz");
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setSharedPluginData("shared", "foo", "baz");
 
-      expect(instanceRect.getPluginData("foo")).toBe("baz");
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
 
-      instanceRect.setPluginData("foo", "");
+      it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+        const component = figma.createComponent();
+        const componentRect = figma.createRectangle();
+        component.appendChild(componentRect);
+        componentRect.setSharedPluginData("shared", "foo", "bar");
 
-      expect(componentRect.getPluginData("foo")).toBe("bar");
-      expect(instanceRect.getPluginData("foo")).toBe("bar");
+        const instance = component.createInstance();
+        const instanceRect = instance.findOne(
+          child => child.type === "RECTANGLE"
+        );
+        instanceRect.setSharedPluginData("shared", "foo", "baz");
+
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("baz");
+
+        instanceRect.setSharedPluginData("shared", "foo", "");
+
+        expect(componentRect.getSharedPluginData("shared", "foo")).toBe("bar");
+        expect(instanceRect.getSharedPluginData("shared", "foo")).toBe("bar");
+      });
     });
   });
 });

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -30,7 +30,7 @@ describe("getPluginData", () => {
     }).toThrow("The node with id 1:2 does not exist");
   });
 
-  fdescribe("components and instances", () => {
+  describe("components and instances", () => {
     it("instances inherit plugin data from main component", () => {
       const component = figma.createComponent();
       component.setPluginData("foo", "bar");

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -29,4 +29,110 @@ describe("getPluginData", () => {
       rect.getPluginData("key");
     }).toThrow("The node with id 1:2 does not exist");
   });
+
+  describe("components and instances", () => {
+    it("instances inherit plugin data from main component", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
+
+    it("the children of instances inherit data from the main component", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
+
+    it("modifying the plugin data of the main component modifies the instance", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+
+      component.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
+
+    it("modifying the plugin data of the main component child modifies the instance child", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      componentRect.setPluginData("foo", "bar");
+      component.appendChild(componentRect);
+
+      const instance = component.createInstance();
+      componentRect.setPluginData("foo", "baz");
+      const instanceRect = instance.findOne(node => node.type === "RECTANGLE");
+
+      expect(instanceRect).not.toBeNull();
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
+
+    it("instances can override the main component plugin data", () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+    });
+
+    it('setting plugin data to "" deletes that key and reverts to the main component\'s pluginData for that key', () => {
+      const component = figma.createComponent();
+      component.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      instance.setPluginData("foo", "baz");
+
+      expect(instance.getPluginData("foo")).toBe("baz");
+
+      instance.setPluginData("foo", "");
+      expect(instance.getPluginData("foo")).toBe("bar");
+    });
+
+    it("the children of instances can override the children of main component plugin data", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
+
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
+
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
+    });
+
+    // it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+    //   const component = figma.createComponent();
+    //   const componentRect = figma.createRectangle();
+    //   component.appendChild(componentRect);
+    //   componentRect.setPluginData("foo", "bar");
+
+    //   const instance = component.createInstance();
+    //   const instanceRect = instance.findOne(
+    //     child => child.type === "RECTANGLE"
+    //   );
+    //   instanceRect.setPluginData("foo", "baz");
+
+    //   expect(instanceRect.getPluginData("foo")).toBe("baz");
+
+    //   componentRect.setPluginData("foo", "");
+
+    //   expect(instanceRect.getPluginData("foo")).toBe("bar");
+    // });
+  });
 });

--- a/src/__tests__/getPluginData.test.ts
+++ b/src/__tests__/getPluginData.test.ts
@@ -30,7 +30,7 @@ describe("getPluginData", () => {
     }).toThrow("The node with id 1:2 does not exist");
   });
 
-  describe("components and instances", () => {
+  fdescribe("components and instances", () => {
     it("instances inherit plugin data from main component", () => {
       const component = figma.createComponent();
       component.setPluginData("foo", "bar");
@@ -116,23 +116,24 @@ describe("getPluginData", () => {
       expect(instanceRect.getPluginData("foo")).toBe("baz");
     });
 
-    // it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
-    //   const component = figma.createComponent();
-    //   const componentRect = figma.createRectangle();
-    //   component.appendChild(componentRect);
-    //   componentRect.setPluginData("foo", "bar");
+    it("setting plugin data to \"\" in an instance child deletes that key and reverts to the main component's corresponding child's pluginData for that key", () => {
+      const component = figma.createComponent();
+      const componentRect = figma.createRectangle();
+      component.appendChild(componentRect);
+      componentRect.setPluginData("foo", "bar");
 
-    //   const instance = component.createInstance();
-    //   const instanceRect = instance.findOne(
-    //     child => child.type === "RECTANGLE"
-    //   );
-    //   instanceRect.setPluginData("foo", "baz");
+      const instance = component.createInstance();
+      const instanceRect = instance.findOne(
+        child => child.type === "RECTANGLE"
+      );
+      instanceRect.setPluginData("foo", "baz");
 
-    //   expect(instanceRect.getPluginData("foo")).toBe("baz");
+      expect(instanceRect.getPluginData("foo")).toBe("baz");
 
-    //   componentRect.setPluginData("foo", "");
+      instanceRect.setPluginData("foo", "");
 
-    //   expect(instanceRect.getPluginData("foo")).toBe("bar");
-    // });
+      expect(componentRect.getPluginData("foo")).toBe("bar");
+      expect(instanceRect.getPluginData("foo")).toBe("bar");
+    });
   });
 });

--- a/src/mixins.ts
+++ b/src/mixins.ts
@@ -167,10 +167,15 @@ export const getBaseNodeMixinStub = (config: TConfig) =>
       if (config.simulateErrors && this.removed) {
         throw new Error(`The node with id ${this.id} does not exist`);
       }
-      if (!this.pluginData) {
-        return [];
-      }
-      return Object.keys(this.pluginData);
+      // get all local and inherited keys
+      const localKeys = this.pluginData ? Object.keys(this.pluginData) : [];
+      const inheritedKeys = this._orig ? this._orig.getPluginDataKeys() : [];
+
+      // combine them into one list and de-dupe any copies
+      const combinedKeys = Array.from(
+        new Set([...localKeys, ...inheritedKeys])
+      );
+      return combinedKeys;
     }
 
     setSharedPluginData(namespace: string, key: string, value: string) {
@@ -209,10 +214,20 @@ export const getBaseNodeMixinStub = (config: TConfig) =>
     }
 
     getSharedPluginDataKeys(namespace: string): string[] {
-      if (!this.sharedPluginData || !this.sharedPluginData[namespace]) {
-        return;
-      }
-      return Object.keys(this.sharedPluginData[namespace]);
+      // get all local and inherited keys
+      const localKeys =
+        this.sharedPluginData && this.sharedPluginData[namespace]
+          ? Object.keys(this.sharedPluginData[namespace])
+          : [];
+      const inheritedKeys = this._orig
+        ? this._orig.getSharedPluginDataKeys(namespace)
+        : [];
+
+      // combine them into one list and de-dupe any copies
+      const combinedKeys = Array.from(
+        new Set([...localKeys, ...inheritedKeys])
+      );
+      return combinedKeys;
     }
 
     setRelaunchData(data: { [command: string]: string }) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -207,7 +207,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.pluginData) {
         this.pluginData = {};
       }
-      this.pluginData[key] = value;
+      if (value === "") {
+        delete this.pluginData[key];
+      } else {
+        this.pluginData[key] = value;
+      }
     }
 
     getPluginData(key: string) {
@@ -243,7 +247,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.sharedPluginData[namespace]) {
         this.sharedPluginData[namespace] = {};
       }
-      this.sharedPluginData[namespace][key] = value;
+      if (value === "") {
+        delete this.sharedPluginData[namespace][key];
+      } else {
+        this.sharedPluginData[namespace][key] = value;
+      }
     }
 
     getSharedPluginData(namespace: string, key: string) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,5 +1,3 @@
-import * as cloneDeep from "clone-deep";
-import * as isPlainObject from "is-plain-object";
 import { Subject, Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 import { applyMixins } from "./applyMixins";
@@ -199,8 +197,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
     name: string;
     removed: boolean;
     relaunchData: { [command: string]: string };
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     setPluginData(key: string, value: string) {
       if (!this.pluginData) {
@@ -366,6 +364,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   }
   class RectangleNodeStub {
     type = "RECTANGLE";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(RectangleNodeStub, [
@@ -377,9 +377,13 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   class TextNodeStub {
     type = "TEXT";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     private _fontName: FontName;
     private _characters: string;
     private _textAutoResize: string;
+
     get fontName() {
       return this._fontName || { family: "Roboto", style: "Regular" };
     }
@@ -492,6 +496,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class DocumentNodeStub {
     type = "DOCUMENT";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(DocumentNodeStub, [BaseNodeMixinStub, ChildrenMixinStub]);
@@ -499,6 +505,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class PageNodeStub {
     type = "PAGE";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     _selection: Array<SceneNode>;
 
     get selection() {
@@ -520,6 +529,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class FrameNodeStub {
     type = "FRAME";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
   }
 
   applyMixins(FrameNodeStub, [
@@ -532,6 +543,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   class GroupNodeStub {
     type = "GROUP";
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     set constraints(value) {
       if (joinedConfig.simulateErrors) {
@@ -549,6 +562,19 @@ export const createFigma = (config: TConfig): PluginAPI => {
     LayoutMixinStub
   ]);
 
+  function cloneChildren(node) {
+    const clone = new node.constructor();
+    for (let key in node) {
+      clone[key] = node[key];
+    }
+    if ("children" in node) {
+      clone.children = node.children.map(cloneChildren);
+    }
+    clone.pluginData = Object.create(node.pluginData);
+    clone.sharedPluginData = Object.create(node.sharedPluginData);
+    return clone;
+  }
+
   class ComponentNodeStub {
     type = "COMPONENT";
     children = [];
@@ -557,7 +583,7 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
     createInstance() {
       const instance = new InstanceNodeStub();
-      instance.children = cloneDeep(this.children);
+      instance.children = this.children.map(cloneChildren);
       instance.pluginData = Object.create(this.pluginData);
       instance.sharedPluginData = Object.create(this.sharedPluginData);
       return instance;
@@ -575,8 +601,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     detachInstance(): void {
       this.type = "FRAME";
@@ -609,8 +635,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
     removed: boolean;
 
     relaunchData: { [command: string]: string };
-    pluginData: { [key: string]: string };
-    sharedPluginData: { [namespace: string]: { [key: string]: string } };
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
 
     setPluginData(key: string, value: string) {
       if (!this.pluginData) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -1,4 +1,5 @@
 import * as cloneDeep from "clone-deep";
+import * as isPlainObject from "is-plain-object";
 import { Subject, Subscription } from "rxjs";
 import { take } from "rxjs/operators";
 import { applyMixins } from "./applyMixins";
@@ -205,7 +206,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.pluginData) {
         this.pluginData = {};
       }
-      this.pluginData[key] = value;
+      if (value === "") {
+        delete this.pluginData[key];
+      } else {
+        this.pluginData[key] = value;
+      }
     }
 
     getPluginData(key: string) {
@@ -235,7 +240,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.sharedPluginData[namespace]) {
         this.sharedPluginData[namespace] = {};
       }
-      this.sharedPluginData[namespace][key] = value;
+      if (value === "") {
+        delete this.sharedPluginData[namespace][key];
+      } else {
+        this.sharedPluginData[namespace][key] = value;
+      }
     }
 
     getSharedPluginData(namespace: string, key: string) {
@@ -543,9 +552,14 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class ComponentNodeStub {
     type = "COMPONENT";
     children = [];
+    pluginData: { [key: string]: string } = {};
+    sharedPluginData: { [namespace: string]: { [key: string]: string } } = {};
+
     createInstance() {
       const instance = new InstanceNodeStub();
       instance.children = cloneDeep(this.children);
+      instance.pluginData = Object.create(this.pluginData);
+      instance.sharedPluginData = Object.create(this.sharedPluginData);
       return instance;
     }
   }
@@ -561,6 +575,8 @@ export const createFigma = (config: TConfig): PluginAPI => {
   class InstanceNodeStub {
     type = "INSTANCE";
     children: any;
+    pluginData: { [key: string]: string };
+    sharedPluginData: { [namespace: string]: { [key: string]: string } };
 
     detachInstance(): void {
       this.type = "FRAME";
@@ -569,6 +585,7 @@ export const createFigma = (config: TConfig): PluginAPI => {
 
   applyMixins(InstanceNodeStub, [
     BaseNodeMixinStub,
+    ChildrenMixinStub,
     ExportMixinStub,
     LayoutMixinStub
   ]);
@@ -599,7 +616,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.pluginData) {
         this.pluginData = {};
       }
-      this.pluginData[key] = value;
+      if (value === "") {
+        delete this.pluginData[key];
+      } else {
+        this.pluginData[key] = value;
+      }
     }
 
     getPluginData(key: string) {
@@ -629,7 +650,11 @@ export const createFigma = (config: TConfig): PluginAPI => {
       if (!this.sharedPluginData[namespace]) {
         this.sharedPluginData[namespace] = {};
       }
-      this.sharedPluginData[namespace][key] = value;
+      if (value === "") {
+        delete this.sharedPluginData[namespace][key];
+      } else {
+        this.sharedPluginData[namespace][key] = value;
+      }
     }
 
     getSharedPluginData(namespace: string, key: string) {

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -572,6 +572,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
     }
     clone.pluginData = Object.create(node.pluginData);
     clone.sharedPluginData = Object.create(node.sharedPluginData);
+    Object.entries(node.sharedPluginData).forEach(([key, val]) => {
+      clone.sharedPluginData[key] = Object.create(val as object);
+    });
     return clone;
   }
 
@@ -587,6 +590,9 @@ export const createFigma = (config: TConfig): PluginAPI => {
       instance.children = this.children.map(cloneChildren);
       instance.pluginData = Object.create(this.pluginData);
       instance.sharedPluginData = Object.create(this.sharedPluginData);
+      Object.entries(this.sharedPluginData).forEach(([key, val]) => {
+        instance.sharedPluginData[key] = Object.create(val as object);
+      });
       instance.mainComponent = this;
       return instance;
     }


### PR DESCRIPTION
A different attempt at what I was trying to do in [this PR](https://github.com/react-figma/figma-api-stub/pull/41). Instead of trying to use prototypes, this stores the original node on a private field called `_orig`, so if we don't find a pluginData property, we can just go up the chain of `node._orig.getPluginData(...)` until we find something. I think the only weird, prototype-y thing I had to do was bind functions in the `cloneChildren` function.

In order to re-use `pluginData` methods, I ended up extending the `BaseNodeMixinStub` on all classes that should use it, kind of like how the Styles extend BaseStyle. I'm not sure if this is the best approach, or if you think we should try doing that in `applyMixins` somewhere 🤔. 