### PR TITLE
Adds some missing APIs

### DIFF
--- a/src/__tests__/globals.test.ts
+++ b/src/__tests__/globals.test.ts
@@ -1,0 +1,17 @@
+import { createFigma } from "../stubs";
+
+describe("globals", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({});
+  });
+
+  it("can use showUI with global variables", () => {
+    expect(() => {
+      figma.showUI(__html__);
+    }).not.toThrow();
+    expect(() => {
+      figma.showUI(__uiFiles__.secondary);
+    }).not.toThrow();
+  });
+});

--- a/src/__tests__/postmessage.test.ts
+++ b/src/__tests__/postmessage.test.ts
@@ -47,3 +47,62 @@ describe("postMessage", () => {
     });
   });
 });
+
+describe('on("message")', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    // @ts-ignore
+    global.figma = createFigma({});
+    // @ts-ignore
+    global.parent.postMessage = createParentPostMessage(global.figma);
+  });
+
+  it("can add a listener for a message", () => {
+    const cb = jest.fn();
+    figma.ui.on("message", cb);
+
+    parent.postMessage({ pluginMessage: "abc" }, "*");
+    parent.postMessage({ pluginMessage: "def" }, "*");
+
+    jest.runAllTimers();
+
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb).toHaveBeenCalledWith("abc", expect.any(Object));
+    expect(cb).toHaveBeenCalledWith("def", expect.any(Object));
+  });
+
+  it("can remove a listener for a message", () => {
+    const cb = jest.fn();
+    figma.ui.on("message", cb);
+
+    parent.postMessage({ pluginMessage: "abc" }, "*");
+
+    jest.runAllTimers();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith("abc", expect.any(Object));
+
+    cb.mockClear();
+    figma.ui.off("message", cb);
+
+    parent.postMessage({ pluginMessage: "def" }, "*");
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("can call a listener once", () => {
+    const cb = jest.fn();
+    figma.ui.once("message", cb);
+
+    parent.postMessage({ pluginMessage: "abc" }, "*");
+    parent.postMessage({ pluginMessage: "def" }, "*");
+
+    jest.runAllTimers();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith("abc", expect.any(Object));
+  });
+});

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -39,6 +39,12 @@ export const createFigma = (paramConfig: TConfig): PluginAPI => {
   const LayoutMixinStub = getLayoutMixinStub(config);
   const ChildrenMixinStub = getChildrenMixinStub(config);
 
+  // @ts-ignore
+  global.__html__ = "main.html";
+
+  // @ts-ignore
+  global.__uiFiles__ = {};
+
   applyMixins(RectangleNodeStub, [
     BaseNodeMixinStub,
     LayoutMixinStub,

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -541,6 +541,10 @@ export const createFigma = (paramConfig: TConfig): PluginAPI => {
       };
       return _genNodeById([figma.root], id) || null;
     }
+
+    notify() {
+      return { cancel: () => {} };
+    }
   }
 
   // @ts-ignore

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -256,6 +256,8 @@ export const createFigma = (paramConfig: TConfig): PluginAPI => {
       currentPageChangeSubject.next();
     }
 
+    skipInvisibleInstanceChildren: boolean = false;
+
     // @ts-ignore
     createPage() {
       const result: any = new PageNodeStub(config);

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -144,7 +144,40 @@ export const createFigma = (paramConfig: TConfig): PluginAPI => {
   };
 
   class UIAPIStub {
+    _listeners = new Set<MessageEventHandler>();
+
     onmessage: MessageEventHandler | undefined;
+
+    on: (type: "message", cb: MessageEventHandler | undefined) => void = (
+      type,
+      cb
+    ) => {
+      if (type === "message" && cb) {
+        this._listeners.add(cb);
+      }
+    };
+
+    off: (type: "message", cb: MessageEventHandler | undefined) => void = (
+      type,
+      cb
+    ) => {
+      if (type === "message" && cb) {
+        this._listeners.delete(cb);
+      }
+    };
+
+    once: (type: "message", cb: MessageEventHandler | undefined) => void = (
+      type,
+      cb
+    ) => {
+      if (type === "message" && cb) {
+        const wrappedCb = (pluginMessage, props) => {
+          cb(pluginMessage, props);
+          this.off("message", wrappedCb);
+        };
+        this.on("message", wrappedCb);
+      }
+    };
 
     postMessage(pluginMessage: any, options?: UIPostMessageOptions): void {
       const message = {
@@ -522,6 +555,18 @@ export const createParentPostMessage = (
     const call = () => {
       // @ts-ignore
       figma.ui.onmessage(message.pluginMessage, { origin: null });
+    };
+    if (isWithoutTimeout) {
+      call();
+    } else {
+      setTimeout(call, 0);
+    }
+  } else {
+    const call = () => {
+      // @ts-ignore
+      figma.ui._listeners.forEach((cb: MessageEventHandler) => {
+        cb(message.pluginMessage, { origin: null });
+      });
     };
     if (isWithoutTimeout) {
       call();

--- a/src/stubs.ts
+++ b/src/stubs.ts
@@ -551,6 +551,8 @@ export const createFigma = (paramConfig: TConfig): PluginAPI => {
     notify() {
       return { cancel: () => {} };
     }
+
+    showUI() {}
   }
 
   // @ts-ignore


### PR DESCRIPTION
I noticed there were a few APIs missing from this package that I had to stub out myself, so I decided to add some of those back to this repo. Here are some of the changes:

* `figma.ui.on`, `figma.ui.off` and `figma.ui.once` - Added implementations for each of these and wrote some tests in `postmessage.test.ts`. These don't use the Observable method that `figma.on` is using, so let me know if you want me to try it that way for a closer implementation
* `figma.notify` - This is just a pretty basic stub function that returns an object with a `cancel` method. Not really a good way to test something like `onDequeue`, but since that interaction happens entirely through the UI, I don't know if there's a good way to unit test that anyway
* `figma.showUI` and global `__html__` and `__uiFiles__` - These are also some really basic stubs that don't really do anything. I wrote some tests in a file called `globals.test.ts` to make sure that the expected use-cases don't cause any crashes.
* `figma.skipInvisibleInstanceChildren` - created this field with a default value of `false` to reflect how that's initially set up in Figma

I'm not particularly attached to any of these implementations, so feel free to suggest any improvements! Also, let me know if you'd rather I remove any of these from this PR.